### PR TITLE
Complete test coverage for `PaymentEscrow`

### DIFF
--- a/test/src/PaymentEscrow/preApprove.t.sol
+++ b/test/src/PaymentEscrow/preApprove.t.sol
@@ -5,11 +5,10 @@ import {PaymentEscrow} from "../../../src/PaymentEscrow.sol";
 import {PaymentEscrowBase} from "../../base/PaymentEscrowBase.sol";
 
 contract PreApproveTest is PaymentEscrowBase {
-    function test_reverts_ifSenderIsNotBuyer(address invalidSender, uint256 amount) public {
+    function test_reverts_ifSenderIsNotBuyer(address invalidSender, uint120 amount) public {
         vm.assume(invalidSender != buyerEOA);
         vm.assume(invalidSender != address(0));
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -19,9 +18,8 @@ contract PreApproveTest is PaymentEscrowBase {
         paymentEscrow.preApprove(paymentDetails);
     }
 
-    function test_reverts_ifPaymentIsAlreadyAuthorized(uint256 amount) public {
+    function test_reverts_ifPaymentIsAlreadyAuthorized(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -40,9 +38,8 @@ contract PreApproveTest is PaymentEscrowBase {
         paymentEscrow.preApprove(paymentDetails);
     }
 
-    function test_succeeds_ifCalledByBuyer(uint256 amount) public {
+    function test_succeeds_ifCalledByBuyer(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -60,9 +57,8 @@ contract PreApproveTest is PaymentEscrowBase {
         paymentEscrow.authorize(amount, paymentDetails, ""); // Empty signature should work after pre-approval
     }
 
-    function test_succeeds_ifCalledByBuyerMultipleTimes(uint256 amount) public {
+    function test_succeeds_ifCalledByBuyerMultipleTimes(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -81,9 +77,8 @@ contract PreApproveTest is PaymentEscrowBase {
         paymentEscrow.authorize(amount, paymentDetails, ""); // Empty signature should work after pre-approval
     }
 
-    function test_emitsExpectedEvents(uint256 amount) public {
+    function test_emitsExpectedEvents(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});

--- a/test/src/PaymentEscrow/reclaim.t.sol
+++ b/test/src/PaymentEscrow/reclaim.t.sol
@@ -5,11 +5,10 @@ import {PaymentEscrow} from "../../../src/PaymentEscrow.sol";
 import {PaymentEscrowBase} from "../../base/PaymentEscrowBase.sol";
 
 contract ReclaimTest is PaymentEscrowBase {
-    function test_reverts_ifSenderIsNotBuyer(address invalidSender, uint256 amount) public {
+    function test_reverts_ifSenderIsNotBuyer(address invalidSender, uint120 amount) public {
         vm.assume(invalidSender != buyerEOA);
         vm.assume(invalidSender != address(0));
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -28,9 +27,8 @@ contract ReclaimTest is PaymentEscrowBase {
         paymentEscrow.reclaim(paymentDetails);
     }
 
-    function test_reverts_ifBeforeCaptureDeadline(uint256 amount, uint48 currentTime) public {
+    function test_reverts_ifBeforeCaptureDeadline(uint120 amount, uint48 currentTime) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         uint48 captureDeadline = uint48(block.timestamp + 1 days);
         vm.assume(currentTime < captureDeadline);
@@ -57,9 +55,8 @@ contract ReclaimTest is PaymentEscrowBase {
         paymentEscrow.reclaim(paymentDetails);
     }
 
-    function test_reverts_ifAuthorizedValueIsZero(uint256 amount) public {
+    function test_reverts_ifAuthorizedValueIsZero(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -73,9 +70,8 @@ contract ReclaimTest is PaymentEscrowBase {
         paymentEscrow.reclaim(paymentDetails);
     }
 
-    function test_reverts_ifAlreadyReclaimed(uint256 amount) public {
+    function test_reverts_ifAlreadyReclaimed(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
@@ -100,9 +96,8 @@ contract ReclaimTest is PaymentEscrowBase {
         paymentEscrow.reclaim(paymentDetails);
     }
 
-    function test_succeeds_ifCalledByBuyerAfterCaptureDeadline(uint256 amount, uint48 timeAfterDeadline) public {
+    function test_succeeds_ifCalledByBuyerAfterCaptureDeadline(uint120 amount, uint48 timeAfterDeadline) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         uint48 captureDeadline = uint48(block.timestamp + 1 days);
         vm.assume(timeAfterDeadline > captureDeadline);
@@ -134,9 +129,8 @@ contract ReclaimTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(address(paymentEscrow)), escrowBalanceBefore - amount);
     }
 
-    function test_emitsExpectedEvents(uint256 amount) public {
+    function test_emitsExpectedEvents(uint120 amount) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});

--- a/test/src/PaymentEscrow/refund.t.sol
+++ b/test/src/PaymentEscrow/refund.t.sol
@@ -25,9 +25,11 @@ contract RefundTest is PaymentEscrowBase {
         paymentEscrow.refund(overflowValue, paymentDetails);
     }
 
-    function test_reverts_whenSenderNotOperatorOrCaptureAddress() public {
-        uint256 authorizedAmount = 100e6;
-        uint256 refundAmount = 60e6;
+    function test_reverts_whenSenderNotOperatorOrCaptureAddress(uint120 authorizedAmount, uint120 refundAmount)
+        public
+    {
+        vm.assume(authorizedAmount > 0);
+        vm.assume(refundAmount > 0);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization(buyerEOA, authorizedAmount);
@@ -38,7 +40,7 @@ contract RefundTest is PaymentEscrowBase {
         paymentEscrow.refund(refundAmount, paymentDetails);
     }
 
-    function test_reverts_whenRefundExceedsCaptured(uint256 authorizedAmount) public {
+    function test_reverts_whenRefundExceedsCaptured(uint120 authorizedAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 1 && authorizedAmount <= buyerBalance); // Changed from > 0 to > 1
@@ -67,7 +69,7 @@ contract RefundTest is PaymentEscrowBase {
         paymentEscrow.refund(refundAmount, paymentDetails);
     }
 
-    function test_succeeds_whenCalledByOperator(uint256 authorizedAmount, uint256 refundAmount) public {
+    function test_succeeds_whenCalledByOperator(uint120 authorizedAmount, uint120 refundAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 0 && authorizedAmount <= buyerBalance);
@@ -103,7 +105,7 @@ contract RefundTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(buyerEOA), buyerBalanceBefore + refundAmount);
     }
 
-    function test_succeeds_whenCalledByCaptureAddress(uint256 authorizedAmount, uint256 refundAmount) public {
+    function test_succeeds_whenCalledByCaptureAddress(uint120 authorizedAmount, uint120 refundAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 0 && authorizedAmount <= buyerBalance);
@@ -139,10 +141,11 @@ contract RefundTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(buyerEOA), buyerBalanceBefore + refundAmount);
     }
 
-    function test_emitsCorrectEvents() public {
-        uint256 authorizedAmount = 100e6;
-        uint256 refundAmount = 60e6;
+    function test_emitsCorrectEvents(uint120 authorizedAmount, uint120 refundAmount) public {
+        vm.assume(authorizedAmount > 0);
+        vm.assume(refundAmount > 0 && refundAmount <= authorizedAmount);
 
+        mockERC3009Token.mint(buyerEOA, authorizedAmount);
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization(buyerEOA, authorizedAmount);
 

--- a/test/src/PaymentEscrow/refundWithSponsor.t.sol
+++ b/test/src/PaymentEscrow/refundWithSponsor.t.sol
@@ -67,13 +67,19 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
         );
     }
 
-    function test_reverts_ifSenderIsInvalid(address invalidSender, uint48 refundDeadline, uint256 refundSalt) public {
+    function test_reverts_ifSenderIsInvalid(
+        uint120 amount,
+        address invalidSender,
+        uint48 refundDeadline,
+        uint256 refundSalt
+    ) public {
+        vm.assume(amount > 0);
         vm.assume(invalidSender != operator);
         vm.assume(invalidSender != captureAddress);
         vm.assume(invalidSender != address(0));
         vm.assume(refundDeadline > block.timestamp);
 
-        uint256 amount = 100e6;
+        mockERC3009Token.mint(buyerEOA, amount);
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
         bytes memory signature = _signPaymentDetails(paymentDetails, BUYER_EOA_PK);
@@ -140,13 +146,12 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     }
 
     function test_reverts_ifSignatureIsInvalid(
-        uint256 amount,
+        uint120 amount,
         bytes calldata invalidSignature,
         uint48 refundDeadline,
         uint256 refundSalt
     ) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(refundDeadline > block.timestamp);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
@@ -167,13 +172,12 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     }
 
     function test_reverts_ifSaltIsIncorrect(
-        uint256 amount,
+        uint120 amount,
         uint256 incorrectSalt,
         uint48 refundDeadline,
         uint256 refundSalt
     ) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(incorrectSalt != refundSalt);
         vm.assume(refundDeadline > block.timestamp);
 
@@ -205,14 +209,18 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
         );
     }
 
-    function test_reverts_ifSponsorIsIncorrect(address incorrectSponsor, uint48 refundDeadline, uint256 refundSalt)
-        public
-    {
+    function test_reverts_ifSponsorIsIncorrect(
+        uint120 amount,
+        address incorrectSponsor,
+        uint48 refundDeadline,
+        uint256 refundSalt
+    ) public {
+        vm.assume(amount > 0);
         vm.assume(incorrectSponsor != _sponsor);
         vm.assume(incorrectSponsor != address(0));
         vm.assume(refundDeadline > block.timestamp);
 
-        uint256 amount = 100e6;
+        mockERC3009Token.mint(buyerEOA, amount);
         PaymentEscrow.PaymentDetails memory paymentDetails =
             _createPaymentEscrowAuthorization({buyer: buyerEOA, value: amount});
         bytes memory signature = _signPaymentDetails(paymentDetails, BUYER_EOA_PK);
@@ -240,13 +248,12 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     }
 
     function test_reverts_ifRefundDeadlineIsIncorrect(
-        uint256 amount,
+        uint120 amount,
         uint48 incorrectDeadline,
         uint48 refundDeadline,
         uint256 refundSalt
     ) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(incorrectDeadline != refundDeadline);
         vm.assume(incorrectDeadline > block.timestamp); // Must be future timestamp
         vm.assume(refundDeadline > block.timestamp);
@@ -279,9 +286,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
         );
     }
 
-    function test_succeeds_ifCalledByOperator(uint256 amount, uint48 refundDeadline, uint256 refundSalt) public {
+    function test_succeeds_ifCalledByOperator(uint120 amount, uint48 refundDeadline, uint256 refundSalt) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(refundDeadline > block.timestamp);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
@@ -318,9 +324,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(buyerEOA), buyerBalanceBefore + amount);
     }
 
-    function test_succeeds_ifCalledByCaptureAddress(uint256 amount, uint48 refundDeadline, uint256 refundSalt) public {
+    function test_succeeds_ifCalledByCaptureAddress(uint120 amount, uint48 refundDeadline, uint256 refundSalt) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(refundDeadline > block.timestamp);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
@@ -358,9 +363,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(buyerEOA), buyerBalanceBefore + amount);
     }
 
-    function test_emitsExpectedEvents(uint256 amount, uint48 refundDeadline, uint256 refundSalt) public {
+    function test_emitsExpectedEvents(uint120 amount, uint48 refundDeadline, uint256 refundSalt) public {
         vm.assume(amount > 0);
-        vm.assume(amount <= type(uint120).max);
         vm.assume(refundDeadline > block.timestamp);
 
         PaymentEscrow.PaymentDetails memory paymentDetails =
@@ -400,7 +404,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     // Helper function to sign refund authorization
     function _signRefundAuthorization(
         PaymentEscrow.PaymentDetails memory paymentDetails,
-        uint256 value,
+        uint120 value,
         address sponsorAddress,
         uint48 deadline,
         uint256 salt,

--- a/test/src/PaymentEscrow/void.t.sol
+++ b/test/src/PaymentEscrow/void.t.sol
@@ -17,7 +17,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
         paymentEscrow.void(paymentDetails);
     }
 
-    function test_void_revert_noAuthorization(uint256 authorizedAmount) public {
+    function test_void_revert_noAuthorization(uint120 authorizedAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 0 && authorizedAmount <= buyerBalance);
@@ -32,7 +32,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
         paymentEscrow.void(paymentDetails);
     }
 
-    function test_void_succeeds_withEscrowedFunds(uint256 authorizedAmount) public {
+    function test_void_succeeds_withEscrowedFunds(uint120 authorizedAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 0 && authorizedAmount <= buyerBalance);
@@ -62,7 +62,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
         assertEq(mockERC3009Token.balanceOf(address(paymentEscrow)), 0);
     }
 
-    function test_void_succeeds_whenCalledByCaptureAddress(uint256 authorizedAmount) public {
+    function test_void_succeeds_whenCalledByCaptureAddress(uint120 authorizedAmount) public {
         uint256 buyerBalance = mockERC3009Token.balanceOf(buyerEOA);
 
         vm.assume(authorizedAmount > 0 && authorizedAmount <= buyerBalance);


### PR DESCRIPTION
Adds tests to achieve 100% coverage.
Style cleanup
Orders tests in order of reverts that occur in execution flow

![Screenshot 2025-03-19 at 8 05 12 AM](https://github.com/user-attachments/assets/8f13f6cc-8ac2-46e2-b160-9cc3cbc1dbe4)
