### PR TITLE
Add `CollectorType` check to escrow and token collectors

### DIFF
--- a/src/token-collectors/ERC3009TokenCollector.sol
+++ b/src/token-collectors/ERC3009TokenCollector.sol
@@ -18,6 +18,11 @@ contract ERC3009TokenCollector is TokenCollector {
     }
 
     /// @inheritdoc TokenCollector
+    function getCollectorType() external pure override returns (TokenCollector.CollectorType) {
+        return TokenCollector.CollectorType.Payment;
+    }
+
+    /// @inheritdoc TokenCollector
     function collectTokens(
         PaymentEscrow.PaymentDetails calldata paymentDetails,
         uint256 amount,

--- a/src/token-collectors/Permit2TokenCollector.sol
+++ b/src/token-collectors/Permit2TokenCollector.sol
@@ -13,6 +13,11 @@ contract Permit2TokenCollector is TokenCollector {
         permit2 = ISignatureTransfer(_permit2);
     }
 
+    /// @inheritdoc TokenCollector
+    function getCollectorType() external pure override returns (TokenCollector.CollectorType) {
+        return TokenCollector.CollectorType.Payment;
+    }
+
     function collectTokens(
         PaymentEscrow.PaymentDetails calldata paymentDetails,
         uint256 amount,

--- a/src/token-collectors/PreApprovalTokenCollector.sol
+++ b/src/token-collectors/PreApprovalTokenCollector.sol
@@ -18,6 +18,11 @@ contract PreApprovalTokenCollector is TokenCollector {
 
     constructor(address _paymentEscrow) TokenCollector(_paymentEscrow) {}
 
+    /// @inheritdoc TokenCollector
+    function getCollectorType() external pure override returns (TokenCollector.CollectorType) {
+        return TokenCollector.CollectorType.Payment;
+    }
+
     /// @notice Registers buyer's token approval for a specific payment
     /// @dev Must be called by the buyer specified in the payment details
     /// @param paymentDetails PaymentDetails struct

--- a/src/token-collectors/SpendPermissionTokenCollector.sol
+++ b/src/token-collectors/SpendPermissionTokenCollector.sol
@@ -18,6 +18,11 @@ contract SpendPermissionTokenCollector is TokenCollector {
     }
 
     /// @inheritdoc TokenCollector
+    function getCollectorType() external pure override returns (TokenCollector.CollectorType) {
+        return TokenCollector.CollectorType.Payment;
+    }
+
+    /// @inheritdoc TokenCollector
     function collectTokens(
         PaymentEscrow.PaymentDetails calldata paymentDetails,
         uint256 amount,

--- a/src/token-collectors/TokenCollector.sol
+++ b/src/token-collectors/TokenCollector.sol
@@ -6,6 +6,11 @@ import {PaymentEscrow} from "../PaymentEscrow.sol";
 abstract contract TokenCollector {
     PaymentEscrow public immutable paymentEscrow;
 
+    enum CollectorType {
+        Payment,
+        Refund
+    }
+
     error OnlyPaymentEscrow();
 
     constructor(address _paymentEscrow) {
@@ -26,4 +31,6 @@ abstract contract TokenCollector {
         uint256 amount,
         bytes calldata collectorData
     ) external virtual;
+
+    function getCollectorType() external view virtual returns (CollectorType);
 }

--- a/test/mocks/ERC20UnsafeTransferTokenCollector.sol
+++ b/test/mocks/ERC20UnsafeTransferTokenCollector.sol
@@ -18,6 +18,11 @@ contract ERC20UnsafeTransferTokenCollector is TokenCollector {
 
     constructor(address _paymentEscrow) TokenCollector(_paymentEscrow) {}
 
+    /// @inheritdoc TokenCollector
+    function getCollectorType() external pure override returns (TokenCollector.CollectorType) {
+        return TokenCollector.CollectorType.Payment;
+    }
+
     /// @notice Registers buyer's token approval for a specific payment
     /// @dev Must be called by the buyer specified in the payment details
     /// @param paymentDetails PaymentDetails struct


### PR DESCRIPTION
Adds a function to the TokenCollector interface that requires collectors to declare whether they operate to serve payment-related collections or refund-related collections. This is designed to prevent an authorization from a payer originally meant to serve a payment from being used by a malicious operator in the same original token collector that the payer signed over to grab liquidity for the payer's refund. i.e. avoid refunding a payer with the payer's own leftover funds. 