### PR TITLE
Add `metadata` param to all external functions for event inclusion

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,5 +3,6 @@ src = "src"
 out = "out"
 libs = ["lib"]
 evm_version = "cancun"
+via_ir = true
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/test/gas/gasBenchmark.t.sol
+++ b/test/gas/gasBenchmark.t.sol
@@ -20,7 +20,7 @@ contract GasBenchmarkBase is PaymentEscrowBase {
         bytes memory warmupSignature = _signPaymentInfo(warmupInfo, payer_EOA_PK);
         mockERC3009Token.mint(payerEOA, 1e6);
         vm.prank(operator);
-        paymentEscrow.authorize(warmupInfo, 1e6, hooks[TokenCollector.ERC3009], warmupSignature);
+        paymentEscrow.authorize(warmupInfo, 1e6, hooks[TokenCollector.ERC3009], warmupSignature, hex"");
 
         // Create and sign payment info
         paymentInfo = _createPaymentEscrowAuthorization(payerEOA, BENCHMARK_AMOUNT);
@@ -34,7 +34,7 @@ contract GasBenchmarkBase is PaymentEscrowBase {
 contract AuthorizeGasBenchmark is GasBenchmarkBase {
     function test_authorize_benchmark() public {
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 }
 
@@ -42,7 +42,13 @@ contract ChargeGasBenchmark is GasBenchmarkBase {
     function test_charge_benchmark() public {
         vm.prank(operator);
         paymentEscrow.charge(
-            paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, BENCHMARK_FEE_BPS, feeReceiver
+            paymentInfo,
+            BENCHMARK_AMOUNT,
+            hooks[TokenCollector.ERC3009],
+            signature,
+            BENCHMARK_FEE_BPS,
+            feeReceiver,
+            hex""
         );
     }
 }
@@ -53,12 +59,12 @@ contract CaptureGasBenchmark is GasBenchmarkBase {
 
         // Pre-authorize
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_capture_benchmark() public {
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, BENCHMARK_AMOUNT, BENCHMARK_FEE_BPS, feeReceiver);
+        paymentEscrow.capture(paymentInfo, BENCHMARK_AMOUNT, BENCHMARK_FEE_BPS, feeReceiver, hex"");
     }
 }
 
@@ -68,12 +74,12 @@ contract VoidGasBenchmark is GasBenchmarkBase {
 
         // Pre-authorize
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_void_benchmark() public {
         vm.prank(operator);
-        paymentEscrow.void(paymentInfo);
+        paymentEscrow.void(paymentInfo, hex"");
     }
 }
 
@@ -83,7 +89,7 @@ contract ReclaimGasBenchmark is GasBenchmarkBase {
 
         // Pre-authorize
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Warp past authorization expiry
         vm.warp(paymentInfo.authorizationExpiry);
@@ -91,7 +97,7 @@ contract ReclaimGasBenchmark is GasBenchmarkBase {
 
     function test_reclaim_benchmark() public {
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 }
 
@@ -101,9 +107,9 @@ contract RefundGasBenchmark is GasBenchmarkBase {
 
         // Pre-authorize and capture
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.ERC3009], signature, hex"");
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, BENCHMARK_AMOUNT, BENCHMARK_FEE_BPS, feeReceiver);
+        paymentEscrow.capture(paymentInfo, BENCHMARK_AMOUNT, BENCHMARK_FEE_BPS, feeReceiver, hex"");
 
         // Give operator tokens for refund and approve collector
         mockERC3009Token.mint(operator, BENCHMARK_AMOUNT);
@@ -113,6 +119,6 @@ contract RefundGasBenchmark is GasBenchmarkBase {
 
     function test_refund_benchmark() public {
         vm.prank(operator);
-        paymentEscrow.refund(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.OperatorRefund], "");
+        paymentEscrow.refund(paymentInfo, BENCHMARK_AMOUNT, hooks[TokenCollector.OperatorRefund], "", hex"");
     }
 }

--- a/test/mocks/ReentrantTokenCollector.sol
+++ b/test/mocks/ReentrantTokenCollector.sol
@@ -22,7 +22,7 @@ contract ReentrantTokenCollector is Test, TokenCollector {
             PaymentEscrow.PaymentInfo memory paymentInfo2 = paymentInfo; // calldata is read-only
             paymentInfo2.salt += 1; // avoid hash repeat
             vm.startPrank(address(paymentInfo.operator));
-            paymentEscrow.authorize(paymentInfo2, 10 ether, address(this), "");
+            paymentEscrow.authorize(paymentInfo2, 10 ether, address(this), "", hex"");
             vm.stopPrank();
         } else {
             called = false;

--- a/test/src/PaymentEscrow/authorize/ERC20Approval.t.sol
+++ b/test/src/PaymentEscrow/authorize/ERC20Approval.t.sol
@@ -25,7 +25,7 @@ contract AuthorizeWithERC20ApprovalTest is PaymentEscrowSmartWalletBase {
         vm.expectRevert(
             abi.encodeWithSelector(PreApprovalPaymentCollector.PaymentNotPreApproved.selector, paymentInfoHash)
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "");
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "", hex"");
     }
 
     function test_reverts_tokenIsPreApprovedButFundsAreNotTransferred(uint120 amount) public {
@@ -43,7 +43,7 @@ contract AuthorizeWithERC20ApprovalTest is PaymentEscrowSmartWalletBase {
         // Try to authorize - should fail on token transfer
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(SafeTransferLib.TransferFromFailed.selector));
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "");
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "", hex"");
     }
 
     function test_reverts_ifHookDoesNotTransferCorrectAmount(uint120 amount) public {
@@ -66,7 +66,7 @@ contract AuthorizeWithERC20ApprovalTest is PaymentEscrowSmartWalletBase {
         // Try to authorize - should fail on token transfer
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.TokenCollectionFailed.selector));
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20UnsafeTransfer], "");
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20UnsafeTransfer], "", hex"");
     }
 
     function test_succeeds_ifTokenIsPreApproved(uint120 amount) public {
@@ -88,7 +88,7 @@ contract AuthorizeWithERC20ApprovalTest is PaymentEscrowSmartWalletBase {
 
         // Authorize with ERC20Approval method
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "");
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], "", hex"");
 
         // Verify balances
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore - amount);

--- a/test/src/PaymentEscrow/authorize/ERC3009.t.sol
+++ b/test/src/PaymentEscrow/authorize/ERC3009.t.sol
@@ -14,7 +14,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(PaymentEscrow.ZeroAmount.selector);
-        paymentEscrow.authorize(paymentInfo, 0, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, 0, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenAmountOverflows(uint256 overflowValue) public {
@@ -27,7 +27,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.AmountOverflow.selector, overflowValue, type(uint120).max));
-        paymentEscrow.authorize(paymentInfo, overflowValue, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, overflowValue, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenCallerIsNotOperator(address invalidSender, uint120 amount) public {
@@ -45,7 +45,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, invalidSender, paymentInfo.operator)
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenValueExceedsAuthorized(uint120 authorizedAmount) public {
@@ -62,7 +62,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.ExceedsMaxAmount.selector, confirmAmount, authorizedAmount)
         );
-        paymentEscrow.authorize(paymentInfo, confirmAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, confirmAmount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_exactlyAtPreApprovalExpiry(uint120 amount) public {
@@ -83,7 +83,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.AfterPreApprovalExpiry.selector, preApprovalExpiry, preApprovalExpiry)
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_afterPreApprovalExpiry(uint120 amount) public {
@@ -106,7 +106,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
                 PaymentEscrow.AfterPreApprovalExpiry.selector, preApprovalExpiry + 1, preApprovalExpiry
             )
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenPreApprovalExpiryAfterAuthorizationExpiry(
@@ -137,7 +137,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
                 PaymentEscrow.InvalidExpiries.selector, preApprovalExpiry, authorizationExpiry, refundExpiry
             )
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenAuthorizationExpiryAfterRefundExpiry(
@@ -168,7 +168,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
                 PaymentEscrow.InvalidExpiries.selector, preApprovalExpiry, authorizationExpiry, refundExpiry
             )
         );
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenFeeBpsTooHigh(uint120 amount) public {
@@ -184,7 +184,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.FeeBpsOverflow.selector, 10_001));
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_reverts_whenAlreadyAuthorized(uint120 amount) public {
@@ -198,14 +198,14 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         // First authorization
         mockERC3009Token.mint(payerEOA, amount);
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Try to authorize again with same payment info
         mockERC3009Token.mint(payerEOA, amount);
         bytes32 paymentInfoHash = paymentEscrow.getHash(paymentInfo);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.PaymentAlreadyCollected.selector, paymentInfoHash));
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 
     function test_succeeds_whenValueEqualsAuthorized(uint120 amount) public {
@@ -220,7 +220,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         uint256 payerBalanceBefore = mockERC3009Token.balanceOf(payerEOA);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         assertEq(mockERC3009Token.balanceOf(address(paymentEscrow)), amount);
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore - amount);
@@ -241,7 +241,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         uint256 payerBalanceBefore = mockERC3009Token.balanceOf(payerEOA);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, confirmAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, confirmAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         assertEq(mockERC3009Token.balanceOf(address(paymentEscrow)), confirmAmount);
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore - confirmAmount);
@@ -266,7 +266,7 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
         uint256 escrowBalanceBefore = mockERC3009Token.balanceOf(address(paymentEscrow));
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Verify balances - full amount should go to escrow since fees are 0
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore - amount);
@@ -294,11 +294,12 @@ contract AuthorizeWithERC3009Test is PaymentEscrowBase {
             paymentInfo.receiver,
             paymentInfo.token,
             valueToConfirm,
-            hooks[TokenCollector.ERC3009]
+            hooks[TokenCollector.ERC3009],
+            hex""
         );
 
         // Execute confirmation
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, valueToConfirm, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, valueToConfirm, hooks[TokenCollector.ERC3009], signature, hex"");
     }
 }

--- a/test/src/PaymentEscrow/authorize/Permit2.t.sol
+++ b/test/src/PaymentEscrow/authorize/Permit2.t.sol
@@ -42,7 +42,7 @@ contract AuthorizeWithPermit2Test is PaymentEscrowSmartWalletBase {
 
         // Should succeed via Permit2 authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.Permit2], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.Permit2], signature, hex"");
 
         // Verify the transfer worked
         assertEq(plainToken.balanceOf(address(paymentEscrow)), amount);

--- a/test/src/PaymentEscrow/authorize/SpendPermission.t.sol
+++ b/test/src/PaymentEscrow/authorize/SpendPermission.t.sol
@@ -35,7 +35,9 @@ contract AuthorizeWithSpendPermissionTest is PaymentEscrowSmartWalletBase {
 
         // Submit authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.SpendPermission], abi.encode(signature, "")); // Empty collectorData for regular spend
+        paymentEscrow.authorize(
+            paymentInfo, amount, hooks[TokenCollector.SpendPermission], abi.encode(signature, ""), hex""
+        );
 
         // Verify balances
         assertEq(

--- a/test/src/PaymentEscrow/authorize/SpendPermissionWithMagicSpend.t.sol
+++ b/test/src/PaymentEscrow/authorize/SpendPermissionWithMagicSpend.t.sol
@@ -37,7 +37,8 @@ contract AuthorizeWithSpendPermissionWithMagicSpendTest is PaymentEscrowSmartWal
             paymentInfo,
             amount,
             hooks[TokenCollector.SpendPermission],
-            abi.encode(signature, abi.encode(withdrawRequest))
+            abi.encode(signature, abi.encode(withdrawRequest)),
+            hex""
         );
 
         // Verify balances - funds should move from MagicSpend to escrow

--- a/test/src/PaymentEscrow/capture.t.sol
+++ b/test/src/PaymentEscrow/capture.t.sol
@@ -16,11 +16,11 @@ contract CaptureTest is PaymentEscrowBase {
         bytes memory signature = _signPaymentInfo(paymentInfo, payer_EOA_PK);
 
         vm.prank(paymentInfo.operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         vm.prank(sender);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, sender, paymentInfo.operator));
-        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenValueIsZero() public {
@@ -29,7 +29,7 @@ contract CaptureTest is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(PaymentEscrow.ZeroAmount.selector);
-        paymentEscrow.capture(paymentInfo, 0, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, 0, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenAmountOverflows(uint256 overflowValue) public {
@@ -40,7 +40,7 @@ contract CaptureTest is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.AmountOverflow.selector, overflowValue, type(uint120).max));
-        paymentEscrow.capture(paymentInfo, overflowValue, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, overflowValue, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenAfterAuthorizationExpiry(
@@ -62,7 +62,7 @@ contract CaptureTest is PaymentEscrowBase {
 
         vm.warp(paymentInfo.preApprovalExpiry - 1);
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         vm.warp(authorizationExpiry + 1);
         vm.prank(operator);
@@ -71,7 +71,7 @@ contract CaptureTest is PaymentEscrowBase {
                 PaymentEscrow.AfterAuthorizationExpiry.selector, block.timestamp, authorizationExpiry
             )
         );
-        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenInsufficientAuthorization(uint120 authorizedAmount) public {
@@ -88,7 +88,7 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Try to capture more than authorized
         vm.prank(operator);
@@ -97,7 +97,7 @@ contract CaptureTest is PaymentEscrowBase {
                 PaymentEscrow.InsufficientAuthorization.selector, paymentInfoHash, authorizedAmount, captureAmount
             )
         );
-        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_receiverSender(uint120 authorizedAmount) public {
@@ -111,14 +111,14 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Then capture the full amount
         vm.prank(paymentInfo.receiver);
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, paymentInfo.receiver, paymentInfo.operator)
         );
-        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_succeeds_withFullAmount(uint120 authorizedAmount) public {
@@ -132,14 +132,14 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         uint256 feeAmount = authorizedAmount * FEE_BPS / 10_000;
         uint256 receiverExpectedBalance = authorizedAmount - feeAmount;
 
         // Then capture the full amount
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
 
         // Verify balances
         assertEq(mockERC3009Token.balanceOf(receiver), receiverExpectedBalance);
@@ -159,14 +159,14 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         uint256 feeAmount = captureAmount * FEE_BPS / 10_000;
         uint256 receiverExpectedBalance = captureAmount - feeAmount;
 
         // Then capture partial amount
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
 
         // Verify balances and state
         assertEq(mockERC3009Token.balanceOf(receiver), receiverExpectedBalance);
@@ -187,15 +187,15 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // First capture
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, firstCaptureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, firstCaptureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
 
         // Second capture
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, secondCaptureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, secondCaptureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
 
         // Calculate fees for each capture separately to match contract behavior
         uint256 firstFeesAmount = firstCaptureAmount * FEE_BPS / 10_000;
@@ -224,15 +224,15 @@ contract CaptureTest is PaymentEscrowBase {
 
         // First confirm the authorization
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Record expected event
         vm.expectEmit(true, false, false, true);
-        emit PaymentEscrow.PaymentCaptured(paymentInfoHash, captureAmount);
+        emit PaymentEscrow.PaymentCaptured(paymentInfoHash, captureAmount, hex"");
 
         // Execute capture
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenFeeBpsBelowMin(
@@ -256,13 +256,13 @@ contract CaptureTest is PaymentEscrowBase {
         bytes memory signature = _signPaymentInfo(paymentInfo, payer_EOA_PK);
 
         vm.prank(paymentInfo.operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         vm.prank(operator);
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.FeeBpsOutOfRange.selector, captureFeeBps, minFeeBps, maxFeeBps)
         );
-        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_reverts_whenFeeBpsAboveMax(
@@ -287,13 +287,13 @@ contract CaptureTest is PaymentEscrowBase {
         bytes memory signature = _signPaymentInfo(paymentInfo, payer_EOA_PK);
 
         vm.prank(paymentInfo.operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         vm.prank(operator);
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.FeeBpsOutOfRange.selector, captureFeeBps, minFeeBps, maxFeeBps)
         );
-        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, paymentInfo.feeReceiver, hex"");
     }
 
     function test_succeeds_withOperatorSetFeeRecipient(
@@ -320,12 +320,12 @@ contract CaptureTest is PaymentEscrowBase {
         bytes memory signature = _signPaymentInfo(paymentInfo, payer_EOA_PK);
 
         vm.prank(paymentInfo.operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         address newFeeRecipient = address(0xdead);
 
         vm.prank(operator);
-        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, newFeeRecipient);
+        paymentEscrow.capture(paymentInfo, authorizedAmount, captureFeeBps, newFeeRecipient, hex"");
 
         uint256 feeAmount = (uint256(authorizedAmount) * uint256(captureFeeBps)) / 10_000;
         assertEq(mockERC3009Token.balanceOf(newFeeRecipient), feeAmount);

--- a/test/src/PaymentEscrow/charge/ERC20Approval.t.sol
+++ b/test/src/PaymentEscrow/charge/ERC20Approval.t.sol
@@ -24,7 +24,13 @@ contract ChargeWithERC20ApprovalTest is PaymentEscrowBase {
             abi.encodeWithSelector(PreApprovalPaymentCollector.PaymentNotPreApproved.selector, paymentInfoHash)
         );
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC20], "", paymentInfo.minFeeBps, paymentInfo.feeReceiver
+            paymentInfo,
+            amount,
+            hooks[TokenCollector.ERC20],
+            hex"",
+            paymentInfo.minFeeBps,
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -45,7 +51,13 @@ contract ChargeWithERC20ApprovalTest is PaymentEscrowBase {
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(SafeTransferLib.TransferFromFailed.selector));
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC20], "", paymentInfo.minFeeBps, paymentInfo.feeReceiver
+            paymentInfo,
+            amount,
+            hooks[TokenCollector.ERC20],
+            hex"",
+            paymentInfo.minFeeBps,
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -71,7 +83,13 @@ contract ChargeWithERC20ApprovalTest is PaymentEscrowBase {
         // Charge with empty signature
         vm.prank(operator);
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC20], "", paymentInfo.minFeeBps, paymentInfo.feeReceiver
+            paymentInfo,
+            amount,
+            hooks[TokenCollector.ERC20],
+            hex"",
+            paymentInfo.minFeeBps,
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         // Verify balances including fee distribution

--- a/test/src/PaymentEscrow/charge/ERC3009.t.sol
+++ b/test/src/PaymentEscrow/charge/ERC3009.t.sol
@@ -15,7 +15,13 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
         vm.prank(operator);
         vm.expectRevert(PaymentEscrow.ZeroAmount.selector);
         paymentEscrow.charge(
-            paymentInfo, 0, hooks[TokenCollector.ERC3009], signature, paymentInfo.minFeeBps, paymentInfo.feeReceiver
+            paymentInfo,
+            0,
+            hooks[TokenCollector.ERC3009],
+            signature,
+            paymentInfo.minFeeBps,
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -35,7 +41,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -61,7 +68,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -77,7 +85,13 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.ExceedsMaxAmount.selector, chargeAmount, authorizedAmount));
         paymentEscrow.charge(
-            paymentInfo, chargeAmount, hooks[TokenCollector.ERC3009], "", paymentInfo.minFeeBps, paymentInfo.feeReceiver
+            paymentInfo,
+            chargeAmount,
+            hooks[TokenCollector.ERC3009],
+            "",
+            paymentInfo.minFeeBps,
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -107,7 +121,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -145,7 +160,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -183,7 +199,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -198,7 +215,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
         // First authorization
         mockERC3009Token.mint(payerEOA, amount);
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Try to charge now with same payment info
         mockERC3009Token.mint(payerEOA, amount);
@@ -211,7 +228,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -234,7 +252,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         uint256 feeAmount = amount * FEE_BPS / 10_000;
@@ -264,7 +283,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         uint256 feeAmount = chargeAmount * FEE_BPS / 10_000;
@@ -295,7 +315,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             paymentInfo.receiver,
             paymentInfo.token,
             valueToCharge,
-            hooks[TokenCollector.ERC3009]
+            hooks[TokenCollector.ERC3009],
+            hex""
         );
 
         // Execute charge
@@ -306,7 +327,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
     }
 
@@ -331,7 +353,8 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         // Fund operator for refund
@@ -344,7 +367,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
 
         // Execute refund
         vm.prank(operator);
-        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), "");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), hex"", hex"");
 
         // Verify balances
         assertEq(mockERC3009Token.balanceOf(operator), operatorBalanceBefore - refundAmount);
@@ -356,7 +379,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             abi.encodeWithSelector(PaymentEscrow.RefundExceedsCapture.selector, chargeAmount, remainingCaptured)
         );
         vm.prank(operator);
-        paymentEscrow.refund(paymentInfo, chargeAmount, address(operatorRefundCollector), "");
+        paymentEscrow.refund(paymentInfo, chargeAmount, address(operatorRefundCollector), hex"", hex"");
     }
 
     function test_reverts_whenFeeBpsBelowMin(uint120 amount, uint16 minFeeBps, uint16 maxFeeBps, uint16 captureFeeBps)
@@ -381,7 +404,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             abi.encodeWithSelector(PaymentEscrow.FeeBpsOutOfRange.selector, captureFeeBps, minFeeBps, maxFeeBps)
         );
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, paymentInfo.feeReceiver
+            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, paymentInfo.feeReceiver, hex""
         );
     }
 
@@ -409,7 +432,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
             abi.encodeWithSelector(PaymentEscrow.FeeBpsOutOfRange.selector, captureFeeBps, minFeeBps, maxFeeBps)
         );
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, paymentInfo.feeReceiver
+            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, paymentInfo.feeReceiver, hex""
         );
     }
 
@@ -430,7 +453,9 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(PaymentEscrow.ZeroFeeReceiver.selector);
-        paymentEscrow.charge(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, minFeeBps, address(0));
+        paymentEscrow.charge(
+            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, minFeeBps, address(0), hex""
+        );
     }
 
     function test_succeeds_withOperatorSetFeeRecipient(
@@ -462,7 +487,7 @@ contract ChargeWithERC3009Test is PaymentEscrowBase {
 
         vm.prank(operator);
         paymentEscrow.charge(
-            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, newFeeRecipient
+            paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, captureFeeBps, newFeeRecipient, hex""
         );
 
         uint256 feeAmount = (uint256(amount) * uint256(captureFeeBps)) / 10_000;

--- a/test/src/PaymentEscrow/e2eCoinbaseSmartWallet.t.sol
+++ b/test/src/PaymentEscrow/e2eCoinbaseSmartWallet.t.sol
@@ -30,7 +30,8 @@ contract PaymentEscrowSmartWalletE2ETest is PaymentEscrowSmartWalletBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         uint256 feeAmount = amount * FEE_BPS / 10_000;
@@ -64,7 +65,8 @@ contract PaymentEscrowSmartWalletE2ETest is PaymentEscrowSmartWalletBase {
             hooks[TokenCollector.ERC3009],
             signature,
             paymentInfo.minFeeBps,
-            paymentInfo.feeReceiver
+            paymentInfo.feeReceiver,
+            hex""
         );
 
         uint256 feeAmount = amount * FEE_BPS / 10_000;

--- a/test/src/PaymentEscrow/preApprove.t.sol
+++ b/test/src/PaymentEscrow/preApprove.t.sol
@@ -30,7 +30,7 @@ contract PreApproveTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
         bytes32 paymentInfoHash = paymentEscrow.getHash(paymentInfo);
         // Now try to pre-approve
         vm.prank(payerEOA);
@@ -55,7 +55,7 @@ contract PreApproveTest is PaymentEscrowBase {
         vm.stopPrank();
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], ""); // ERC20Approval should work after pre-approval
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC20], hex"", hex""); // ERC20Approval should work after pre-approval
     }
 
     function test_reverts_ifCalledBypayerMultipleTimes(uint120 amount) public {

--- a/test/src/PaymentEscrow/reclaim.t.sol
+++ b/test/src/PaymentEscrow/reclaim.t.sol
@@ -18,13 +18,13 @@ contract ReclaimTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Try to reclaim with invalid sender
         vm.warp(paymentInfo.authorizationExpiry);
         vm.prank(invalidSender);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, invalidSender, paymentInfo.payer));
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 
     function test_reverts_ifBeforeAuthorizationExpiry(uint120 amount, uint48 currentTime) public {
@@ -44,7 +44,7 @@ contract ReclaimTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Try to reclaim before deadline
         vm.warp(currentTime);
@@ -52,7 +52,7 @@ contract ReclaimTest is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.BeforeAuthorizationExpiry.selector, currentTime, authorizationExpiry)
         );
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 
     function test_reverts_ifAuthorizedValueIsZero(uint120 amount) public {
@@ -67,7 +67,7 @@ contract ReclaimTest is PaymentEscrowBase {
             abi.encodeWithSelector(PaymentEscrow.ZeroAuthorization.selector, paymentEscrow.getHash(paymentInfo))
         );
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 
     function test_reverts_ifAlreadyReclaimed(uint120 amount) public {
@@ -81,19 +81,19 @@ contract ReclaimTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Reclaim the payment the first time
         vm.warp(paymentInfo.authorizationExpiry);
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
 
         // Try to reclaim again
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.ZeroAuthorization.selector, paymentEscrow.getHash(paymentInfo))
         );
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 
     function test_succeeds_ifCalledByPayerAfterAuthorizationExpiry(uint120 amount, uint48 timeAfterDeadline) public {
@@ -114,7 +114,7 @@ contract ReclaimTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         uint256 payerBalanceBefore = mockERC3009Token.balanceOf(payerEOA);
         uint256 escrowBalanceBefore = mockERC3009Token.balanceOf(address(paymentEscrow));
@@ -122,7 +122,7 @@ contract ReclaimTest is PaymentEscrowBase {
         // Reclaim after deadline
         vm.warp(timeAfterDeadline);
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
 
         // Verify balances
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore + amount);
@@ -140,16 +140,16 @@ contract ReclaimTest is PaymentEscrowBase {
         mockERC3009Token.mint(payerEOA, amount);
 
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, amount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Prepare for reclaim
         vm.warp(paymentInfo.authorizationExpiry);
 
         bytes32 paymentInfoHash = paymentEscrow.getHash(paymentInfo);
         vm.expectEmit(true, false, false, true);
-        emit PaymentEscrow.PaymentReclaimed(paymentInfoHash, amount);
+        emit PaymentEscrow.PaymentReclaimed(paymentInfoHash, amount, hex"");
 
         vm.prank(payerEOA);
-        paymentEscrow.reclaim(paymentInfo);
+        paymentEscrow.reclaim(paymentInfo, hex"");
     }
 }

--- a/test/src/PaymentEscrow/reentrancy.t.sol
+++ b/test/src/PaymentEscrow/reentrancy.t.sol
@@ -49,7 +49,7 @@ contract ReentrancyApproveTest is PaymentEscrowSmartWalletBase {
 
         // Use low-level call to detect revert
         bytes memory callData = abi.encodeWithSelector(
-            PaymentEscrow.authorize.selector, paymentInfo, 10 ether, address(reentrantTokenCollector), ""
+            PaymentEscrow.authorize.selector, paymentInfo, 10 ether, address(reentrantTokenCollector), "", hex""
         );
 
         (bool success, bytes memory returnData) = address(paymentEscrow).call(callData);
@@ -62,10 +62,10 @@ contract ReentrancyApproveTest is PaymentEscrowSmartWalletBase {
 
         console.log("After authorize attempt");
         vm.expectRevert(); // expect revert because authorize never happened
-        paymentEscrow.capture(paymentInfo, 10 ether, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, 10 ether, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
         paymentInfo.salt += 1; // set up the second unique paymentInfo
         vm.expectRevert(); // expect revert because we've fixed the reentrancy
-        paymentEscrow.capture(paymentInfo, 10 ether, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.capture(paymentInfo, 10 ether, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
         vm.stopPrank();
 
         console.log("After attack Attacker Balance:", mockERC3009Token.balanceOf(attacker));

--- a/test/src/PaymentEscrow/refund.t.sol
+++ b/test/src/PaymentEscrow/refund.t.sol
@@ -11,7 +11,7 @@ contract RefundTest is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(PaymentEscrow.ZeroAmount.selector);
-        paymentEscrow.refund(paymentInfo, 0, address(0), hex"");
+        paymentEscrow.refund(paymentInfo, 0, address(0), hex"", hex"");
     }
 
     function test_reverts_whenAmountOverflows(uint256 overflowValue) public {
@@ -22,7 +22,7 @@ contract RefundTest is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.AmountOverflow.selector, overflowValue, type(uint120).max));
-        paymentEscrow.refund(paymentInfo, overflowValue, address(0), hex"");
+        paymentEscrow.refund(paymentInfo, overflowValue, address(0), hex"", hex"");
     }
 
     function test_reverts_whenSenderNotOperator(uint120 authorizedAmount, uint120 refundAmount) public {
@@ -36,7 +36,7 @@ contract RefundTest is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, randomAddress, paymentInfo.operator)
         );
-        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"", hex"");
     }
 
     function test_reverts_afterRefundExpiry(uint120 authorizedAmount, uint120 refundAmount, uint48 refundExpiry)
@@ -53,7 +53,7 @@ contract RefundTest is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.AfterRefundExpiry.selector, uint48(block.timestamp), refundExpiry)
         );
-        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"", hex"");
     }
 
     function test_reverts_whenRefundExceedsCaptured(uint120 authorizedAmount) public {
@@ -69,8 +69,8 @@ contract RefundTest is PaymentEscrowBase {
 
         // First confirm and capture partial amount
         vm.startPrank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
-        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
+        paymentEscrow.capture(paymentInfo, captureAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
         vm.stopPrank();
 
         // Fund operator for refund
@@ -83,7 +83,7 @@ contract RefundTest is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.RefundExceedsCapture.selector, refundAmount, captureAmount)
         );
-        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(0), hex"", hex"");
     }
 
     function test_succeeds_whenCalledByOperator(uint120 authorizedAmount, uint120 refundAmount) public {
@@ -98,8 +98,8 @@ contract RefundTest is PaymentEscrowBase {
 
         // First confirm and capture the payment
         vm.startPrank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
-        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
+        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
         vm.stopPrank();
 
         // Fund the operator for refund
@@ -114,7 +114,7 @@ contract RefundTest is PaymentEscrowBase {
 
         // Execute refund
         vm.prank(operator);
-        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), hex"");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), hex"", hex"");
 
         // Verify balances
         assertEq(mockERC3009Token.balanceOf(operator), operatorBalanceBefore - refundAmount);
@@ -134,8 +134,8 @@ contract RefundTest is PaymentEscrowBase {
 
         // First confirm and capture the payment
         vm.startPrank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
-        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
+        paymentEscrow.capture(paymentInfo, authorizedAmount, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
         vm.stopPrank();
 
         // Fund operator for refund
@@ -145,10 +145,10 @@ contract RefundTest is PaymentEscrowBase {
 
         // Record expected event
         vm.expectEmit(true, true, false, true);
-        emit PaymentEscrow.PaymentRefunded(paymentInfoHash, refundAmount, address(operatorRefundCollector));
+        emit PaymentEscrow.PaymentRefunded(paymentInfoHash, refundAmount, address(operatorRefundCollector), hex"");
 
         // Execute refund
         vm.prank(operator);
-        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), hex"");
+        paymentEscrow.refund(paymentInfo, refundAmount, address(operatorRefundCollector), hex"", hex"");
     }
 }

--- a/test/src/PaymentEscrow/refundWithSponsor.t.sol
+++ b/test/src/PaymentEscrow/refundWithSponsor.t.sol
@@ -25,8 +25,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(initialAmount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(initialAmount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(initialAmount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(initialAmount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -40,7 +40,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     vm.prank(operator);
     //     vm.expectRevert(PaymentEscrow.ZeroAmount.selector);
-    //     paymentEscrow.refundWithSponsor(0, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature);
+    //     paymentEscrow.refundWithSponsor(0, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex"");
     // }
 
     // function test_refundWithSponsor_reverts_whenAmountOverflows(uint256 overflowValue) public {
@@ -63,7 +63,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     vm.prank(operator);
     //     vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.AmountOverflow.selector, overflowValue, type(uint120).max));
     //     paymentEscrow.refundWithSponsor(
-    //         overflowValue, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature
+    //         overflowValue, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex""
     //     );
     // }
 
@@ -86,8 +86,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -101,7 +101,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     vm.prank(invalidSender);
     //     vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, invalidSender));
-    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature);
+    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex"");
     // }
 
     // function test_reverts_ifValueIsGreaterThanCaptured(
@@ -123,8 +123,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(captureAmount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(captureAmount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(captureAmount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(captureAmount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -141,7 +141,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //         abi.encodeWithSelector(PaymentEscrow.RefundExceedsCapture.selector, refundAmount, captureAmount)
     //     );
     //     paymentEscrow.refundWithSponsor(
-    //         refundAmount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature
+    //         refundAmount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex""
     //     );
     // }
 
@@ -158,17 +158,15 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //         _createPaymentEscrowAuthorization({payer: payerEOA, maxAmount: amount});
     //     bytes memory signature = _signPaymentInfo(paymentInfo, payer_EOA_PK);
 
-    //     mockERC3009Token.mint(payerEOA, amount);
-
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     vm.prank(operator);
     //     vm.expectRevert(); // Expect revert from invalid signature
-    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, invalidSignature);
+    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, invalidSignature, hex"");
     // }
 
     // function test_reverts_ifSaltIsIncorrect(
@@ -189,8 +187,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -205,7 +203,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     vm.prank(operator);
     //     vm.expectRevert(); // Expect revert from mismatched salt
     //     paymentEscrow.refundWithSponsor(
-    //         amount, paymentInfo, _sponsor, refundDeadline, incorrectSalt, sponsorSignature
+    //         amount, paymentInfo, _sponsor, refundDeadline, incorrectSalt, sponsorSignature, hex""
     //     );
     // }
 
@@ -227,8 +225,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -243,7 +241,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     vm.prank(operator);
     //     vm.expectRevert(); // Expect revert from mismatched sponsor
     //     paymentEscrow.refundWithSponsor(
-    //         amount, paymentInfo, incorrectSponsor, refundDeadline, refundSalt, sponsorSignature
+    //         amount, paymentInfo, incorrectSponsor, refundDeadline, refundSalt, sponsorSignature, hex""
     //     );
     // }
 
@@ -266,8 +264,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     bytes memory sponsorSignature = _signRefundAuthorization({
@@ -282,7 +280,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     vm.prank(operator);
     //     vm.expectRevert(); // Expect revert from mismatched deadline
     //     paymentEscrow.refundWithSponsor(
-    //         amount, paymentInfo, _sponsor, incorrectDeadline, refundSalt, sponsorSignature
+    //         amount, paymentInfo, _sponsor, incorrectDeadline, refundSalt, sponsorSignature, hex""
     //     );
     // }
 
@@ -298,8 +296,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     // Fund sponsor
@@ -328,7 +326,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //             refundSalt: refundSalt,
     //             signature: sponsorSignature,
     //             collectorData: ""
-    //         })
+    //         }),
+    //         hex""
     //     );
 
     //     assertEq(mockERC3009Token.balanceOf(_sponsor), sponsorBalanceBefore - amount);
@@ -348,8 +347,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     // Fund sponsor with enough tokens
@@ -368,7 +367,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     uint256 sponsorBalanceBefore = mockERC3009Token.balanceOf(_sponsor);
 
     //     vm.prank(receiver);
-    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature);
+    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex"");
 
     //     assertEq(mockERC3009Token.balanceOf(_sponsor), sponsorBalanceBefore - amount);
     //     assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore + amount);
@@ -389,8 +388,8 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
 
     //     // First authorize and capture
     //     vm.startPrank(operator);
-    //     paymentEscrow.authorize(amount, paymentInfo, signature, "");
-    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver);
+    //     paymentEscrow.authorize(amount, paymentInfo, signature, hex"", hex"");
+    //     paymentEscrow.capture(amount, paymentInfo, paymentInfo.minFeeBps, paymentInfo.feeReceiver, hex"");
     //     vm.stopPrank();
 
     //     // Fund sponsor with enough tokens
@@ -409,7 +408,7 @@ contract RefundWithSponsorTest is PaymentEscrowBase {
     //     emit PaymentEscrow.PaymentRefunded(paymentInfoHash, amount, operator);
 
     //     vm.prank(operator);
-    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature);
+    //     paymentEscrow.refundWithSponsor(amount, paymentInfo, _sponsor, refundDeadline, refundSalt, sponsorSignature, hex"");
     // }
 
     // Helper function to sign refund authorization

--- a/test/src/PaymentEscrow/void.t.sol
+++ b/test/src/PaymentEscrow/void.t.sol
@@ -15,7 +15,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
         vm.expectRevert(
             abi.encodeWithSelector(PaymentEscrow.InvalidSender.selector, randomAddress, paymentInfo.operator)
         );
-        paymentEscrow.void(paymentInfo);
+        paymentEscrow.void(paymentInfo, hex"");
     }
 
     function test_void_revert_noAuthorization(uint120 authorizedAmount) public {
@@ -29,7 +29,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
 
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(PaymentEscrow.ZeroAuthorization.selector, paymentInfoHash));
-        paymentEscrow.void(paymentInfo);
+        paymentEscrow.void(paymentInfo, hex"");
     }
 
     function test_void_succeeds_withEscrowedFunds(uint120 authorizedAmount) public {
@@ -45,7 +45,7 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
 
         // First confirm the authorization to escrow funds
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         uint256 payerBalanceBefore = mockERC3009Token.balanceOf(payerEOA);
         uint256 escrowBalanceBefore = mockERC3009Token.balanceOf(address(paymentEscrow));
@@ -53,8 +53,8 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
         // Then void the authorization
         vm.prank(operator);
         vm.expectEmit(true, false, false, false);
-        emit PaymentEscrow.PaymentVoided(paymentInfoHash, authorizedAmount);
-        paymentEscrow.void(paymentInfo);
+        emit PaymentEscrow.PaymentVoided(paymentInfoHash, authorizedAmount, hex"");
+        paymentEscrow.void(paymentInfo, hex"");
 
         // Verify funds were returned to payer
         assertEq(mockERC3009Token.balanceOf(payerEOA), payerBalanceBefore + escrowBalanceBefore);
@@ -72,14 +72,14 @@ contract AuthorizationVoidedTest is PaymentEscrowBase {
 
         // First confirm the authorization to escrow funds
         vm.prank(operator);
-        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature);
+        paymentEscrow.authorize(paymentInfo, authorizedAmount, hooks[TokenCollector.ERC3009], signature, hex"");
 
         // Record all expected events in order
         vm.expectEmit(true, false, false, false);
-        emit PaymentEscrow.PaymentVoided(paymentInfoHash, authorizedAmount);
+        emit PaymentEscrow.PaymentVoided(paymentInfoHash, authorizedAmount, hex"");
 
         // Then void the authorization and verify events
         vm.prank(operator);
-        paymentEscrow.void(paymentInfo);
+        paymentEscrow.void(paymentInfo, hex"");
     }
 }


### PR DESCRIPTION
Adds a `bytes calldata metadata` param to all external functions that allows offchain metadata to be included in events emitted during payment operations. Convenience connection for offchain indexing and monitoring.