### PR TITLE
Fix integration tests

### DIFF
--- a/test/base/AuthCaptureEscrowBase.sol
+++ b/test/base/AuthCaptureEscrowBase.sol
@@ -50,7 +50,7 @@ contract AuthCaptureEscrowBase is Test, DeployPermit2 {
     address public payerEOA;
     address public feeReceiver;
     uint16 constant FEE_BPS = 100; // 1%
-    uint256 internal constant payer_EOA_PK = 0x1234;
+    uint256 internal constant payer_EOA_PK = 0x0C0DE;
 
     bytes32 constant _RECEIVE_WITH_AUTHORIZATION_TYPEHASH =
         0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8;

--- a/test/base/AuthCaptureEscrowSmartWalletBase.sol
+++ b/test/base/AuthCaptureEscrowSmartWalletBase.sol
@@ -24,8 +24,8 @@ contract AuthCaptureEscrowSmartWalletBase is AuthCaptureEscrowBase {
     address public smartWalletCounterfactual; // The counterfactual address
     CoinbaseSmartWallet public smartWalletDeployed; // Helper instance for using smart wallet functions
     address public deployedWalletOwner;
-    uint256 internal constant COUNTERFACTUAL_WALLET_OWNER_PK = 0x5678; // Different from payer_PK
-    uint256 internal constant DEPLOYED_WALLET_OWNER_PK = 0x1111;
+    uint256 internal constant COUNTERFACTUAL_WALLET_OWNER_PK = 0x0C0DE2; // Different from payer_PK
+    uint256 internal constant DEPLOYED_WALLET_OWNER_PK = 0x0C0DE3;
 
     function setUp() public virtual override {
         super.setUp();


### PR DESCRIPTION
Our integration tests randomly started failing! The issue was the some of the "EOA"s we use in our tests are derived from private keys that are common things like 0x1111, or 0x1234. Now, post-7702 on Base, these EOAs actually have code! This was breaking signature validation flows because the validation code was trying to call the 1271 `isValidSignature` method on these addresses instead of doing basic ecrecover, and these methods aren't/weren't implemented there.

The fix is simply to use different private keys to create our random EOAs that are more random and unlikely to end up with code on the Base fork used in the integration tests. Another way to fix this could have been to tie the fork to a specific block, but we'd ideally like to fork against the most current state of the network.