### PR TITLE
style: fix code formatting to pass CI

### DIFF
--- a/src/AuthCaptureEscrow.sol
+++ b/src/AuthCaptureEscrow.sol
@@ -392,9 +392,7 @@ contract AuthCaptureEscrow is ReentrancyGuardTransient {
     /// @return The operator's token store address
     function getTokenStore(address operator) public view returns (address) {
         return LibClone.predictDeterministicAddress({
-            implementation: tokenStoreImplementation,
-            salt: bytes32(bytes20(operator)),
-            deployer: address(this)
+            implementation: tokenStoreImplementation, salt: bytes32(bytes20(operator)), deployer: address(this)
         });
     }
 
@@ -440,8 +438,7 @@ contract AuthCaptureEscrow is ReentrancyGuardTransient {
         } else if (tokenStore.code.length == 0) {
             // Call failed from undeployed TokenStore, deploy and try again
             tokenStore = LibClone.cloneDeterministic({
-                implementation: tokenStoreImplementation,
-                salt: bytes32(bytes20(operator))
+                implementation: tokenStoreImplementation, salt: bytes32(bytes20(operator))
             });
             emit TokenStoreCreated(operator, tokenStore);
             TokenStore(tokenStore).sendTokens(token, recipient, amount);

--- a/src/collectors/ERC3009PaymentCollector.sol
+++ b/src/collectors/ERC3009PaymentCollector.sol
@@ -39,15 +39,16 @@ contract ERC3009PaymentCollector is TokenCollector, ERC6492SignatureHandler {
         uint256 maxAmount = paymentInfo.maxAmount;
 
         // Pull tokens into this contract
-        IERC3009(token).receiveWithAuthorization({
-            from: payer,
-            to: address(this),
-            value: maxAmount,
-            validAfter: 0,
-            validBefore: paymentInfo.preApprovalExpiry,
-            nonce: _getHashPayerAgnostic(paymentInfo),
-            signature: _handleERC6492Signature(collectorData)
-        });
+        IERC3009(token)
+            .receiveWithAuthorization({
+                from: payer,
+                to: address(this),
+                value: maxAmount,
+                validAfter: 0,
+                validBefore: paymentInfo.preApprovalExpiry,
+                nonce: _getHashPayerAgnostic(paymentInfo),
+                signature: _handleERC6492Signature(collectorData)
+            });
 
         // Return any excess tokens to payer
         if (maxAmount > amount) SafeERC20.safeTransfer(IERC20(token), payer, maxAmount - amount);

--- a/src/collectors/Permit2PaymentCollector.sol
+++ b/src/collectors/Permit2PaymentCollector.sol
@@ -42,7 +42,9 @@ contract Permit2PaymentCollector is TokenCollector, ERC6492SignatureHandler {
     ) internal override {
         permit2.permitTransferFrom({
             permit: ISignatureTransfer.PermitTransferFrom({
-                permitted: ISignatureTransfer.TokenPermissions({token: paymentInfo.token, amount: paymentInfo.maxAmount}),
+                permitted: ISignatureTransfer.TokenPermissions({
+                    token: paymentInfo.token, amount: paymentInfo.maxAmount
+                }),
                 nonce: uint256(_getHashPayerAgnostic(paymentInfo)),
                 deadline: paymentInfo.preApprovalExpiry
             }),

--- a/src/interfaces/IMulticall3.sol
+++ b/src/interfaces/IMulticall3.sol
@@ -26,10 +26,7 @@ interface IMulticall3 {
         bytes returnData;
     }
 
-    function aggregate(Call[] calldata calls)
-        external
-        payable
-        returns (uint256 blockNumber, bytes[] memory returnData);
+    function aggregate(Call[] calldata calls) external payable returns (uint256 blockNumber, bytes[] memory returnData);
 
     function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData);
 

--- a/test/base/AuthCaptureEscrowBase.sol
+++ b/test/base/AuthCaptureEscrowBase.sol
@@ -161,8 +161,9 @@ contract AuthCaptureEscrowBase is Test, DeployPermit2 {
         uint256 validBefore,
         bytes32 nonce
     ) internal view returns (bytes32) {
-        bytes32 structHash =
-            keccak256(abi.encode(_RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce));
+        bytes32 structHash = keccak256(
+            abi.encode(_RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)
+        );
         return keccak256(abi.encodePacked("\x19\x01", IERC3009(token).DOMAIN_SEPARATOR(), structHash));
     }
 

--- a/test/base/AuthCaptureEscrowSmartWalletBase.sol
+++ b/test/base/AuthCaptureEscrowSmartWalletBase.sol
@@ -172,11 +172,7 @@ contract AuthCaptureEscrowSmartWalletBase is AuthCaptureEscrowBase {
         uint256 nonce = uint256(hashPortion);
 
         return MagicSpend.WithdrawRequest({
-            asset: address(0),
-            amount: 0,
-            nonce: nonce,
-            expiry: type(uint48).max,
-            signature: new bytes(0)
+            asset: address(0), amount: 0, nonce: nonce, expiry: type(uint48).max, signature: new bytes(0)
         });
     }
 

--- a/test/src/PaymentEscrow/authorize.t.sol
+++ b/test/src/PaymentEscrow/authorize.t.sol
@@ -321,9 +321,7 @@ contract AuthorizeTest is AuthCaptureEscrowSmartWalletBase {
         vm.assume(maxAmount >= amount && amount > 0);
         mockERC3009Token.mint(address(smartWalletDeployed), amount);
         AuthCaptureEscrow.PaymentInfo memory paymentInfo = _createPaymentInfo({
-            payer: address(smartWalletDeployed),
-            maxAmount: maxAmount,
-            token: address(mockERC3009Token)
+            payer: address(smartWalletDeployed), maxAmount: maxAmount, token: address(mockERC3009Token)
         });
 
         // Create and sign the spend permission

--- a/test/src/collectors/SpendPermissionPaymentCollector.t.sol
+++ b/test/src/collectors/SpendPermissionPaymentCollector.t.sol
@@ -25,9 +25,7 @@ contract SpendPermissionPaymentCollectorTest is AuthCaptureEscrowSmartWalletBase
         MockERC3009Token(address(mockERC3009Token)).mint(address(smartWalletDeployed), amount);
 
         AuthCaptureEscrow.PaymentInfo memory paymentInfo = _createPaymentInfo({
-            payer: address(smartWalletDeployed),
-            maxAmount: amount,
-            token: address(mockERC3009Token)
+            payer: address(smartWalletDeployed), maxAmount: amount, token: address(mockERC3009Token)
         });
         address tokenStore = authCaptureEscrow.getTokenStore(paymentInfo.operator);
 
@@ -47,9 +45,7 @@ contract SpendPermissionPaymentCollectorTest is AuthCaptureEscrowSmartWalletBase
         MockERC3009Token(address(mockERC3009Token)).mint(address(smartWalletDeployed), amount);
 
         AuthCaptureEscrow.PaymentInfo memory paymentInfo = _createPaymentInfo({
-            payer: address(smartWalletDeployed),
-            maxAmount: amount,
-            token: address(mockERC3009Token)
+            payer: address(smartWalletDeployed), maxAmount: amount, token: address(mockERC3009Token)
         });
         address tokenStore = authCaptureEscrow.getTokenStore(paymentInfo.operator);
 
@@ -69,9 +65,7 @@ contract SpendPermissionPaymentCollectorTest is AuthCaptureEscrowSmartWalletBase
         mockERC3009Token.mint(address(magicSpend), amount);
 
         AuthCaptureEscrow.PaymentInfo memory paymentInfo = _createPaymentInfo({
-            payer: address(smartWalletDeployed),
-            maxAmount: amount,
-            token: address(mockERC3009Token)
+            payer: address(smartWalletDeployed), maxAmount: amount, token: address(mockERC3009Token)
         });
         address tokenStore = authCaptureEscrow.getTokenStore(paymentInfo.operator);
 


### PR DESCRIPTION
## Problem
The codebase has formatting inconsistencies that cause `forge fmt --check` to fail in the CI workflow.

## Solution
Applied `forge fmt` to fix formatting issues in 8 files:
- src/AuthCaptureEscrow.sol
- src/collectors/ERC3009PaymentCollector.sol
- src/collectors/Permit2PaymentCollector.sol
- src/interfaces/IMulticall3.sol
- test/base/AuthCaptureEscrowBase.sol
- test/base/AuthCaptureEscrowSmartWalletBase.sol
- test/src/PaymentEscrow/authorize.t.sol
- test/src/collectors/SpendPermissionPaymentCollector.t.sol

## Testing
- `forge fmt --check` now passes
- All 104 tests pass (1 integration test skipped due to missing BASE_RPC_URL env var)