### PR TITLE
Fix typos and broken links in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ The protocol provides six main functions that handle the complete payment lifecy
 - **[Capture](operations/Capture.md)** - Transfer previously authorized funds from escrow to merchants. Supports partial captures and flexible fee distribution.
 
 ### Payment Cancellation
-- **[Void](operations/Void.md)** - Cancel payment authorizations and return escrowed funds to payerss. Only callable by the operator, but can be used to cancel a payment at any time.
+- **[Void](operations/Void.md)** - Cancel payment authorizations and return escrowed funds to payers. Only callable by the operator, but can be used to cancel a payment at any time.
 
 - **[Reclaim](operations/Reclaim.md)** - Allow payers to recover funds from expired authorizations. Payer-initiated safety mechanism callable only after authorization expiry.
 

--- a/docs/operations/Authorize.md
+++ b/docs/operations/Authorize.md
@@ -97,7 +97,7 @@ Track authorizations using the `paymentInfoHash` which uniquely identifies each 
 | `ExceedsMaxAmount` | Amount exceeds paymentInfo.maxAmount |
 | `AfterPreApprovalExpiry` | Called after signature expiry |
 | `InvalidExpiries` | Expiry timestamps are improperly ordered |
-| `FeeBpsOverFlow` | maxFeeBps exceeds maximum value |
+| `FeeBpsOverflow` | maxFeeBps exceeds maximum value |
 | `InvalidFeeBpsRange` | minFeeBps exceeds maxFeeBps |
 | `PaymentAlreadyCollected` | Payment already authorized or charged |
 | `InvalidCollectorForOperation` | Wrong collector type specified |

--- a/docs/operations/Capture.md
+++ b/docs/operations/Capture.md
@@ -28,7 +28,7 @@ function capture(
 ```
 
 ### Process Flow
-1. **Fee Validation**: Ensures fee parameters are within allowed ranges and recipient is valid (see [Fees](Fees.md))
+1. **Fee Validation**: Ensures fee parameters are within allowed ranges and recipient is valid (see [Fees](../Fees.md))
 2. **Timing Check**: Verifies capture occurs before authorization expiry
 3. **Availability Check**: Confirms sufficient authorized funds are available
 4. **State Update**: Reduces `capturableAmount` and increases `refundableAmount` by captured `amount`

--- a/docs/operations/Charge.md
+++ b/docs/operations/Charge.md
@@ -31,7 +31,7 @@ function charge(
 
 ### Process Flow
 1. **Payment Validation**: Ensures payment info is valid and timing constraints are met
-2. **Fee Validation**: Confirms fee parameters are within allowed ranges (see [Fees](Fees.md))
+2. **Fee Validation**: Confirms fee parameters are within allowed ranges (see [Fees](../Fees.md))
 3. **Uniqueness Check**: Verifies this payment hasn't already been collected
 4. **State Update**: Records payment as collected with `refundableAmount`
 5. **Token Collection**: Uses token collector to pull funds from payer
@@ -100,7 +100,7 @@ The `PaymentCharged` event includes more details than `PaymentCaptured` since it
 | `ExceedsMaxAmount` | Amount exceeds paymentInfo.maxAmount |
 | `AfterPreApprovalExpiry` | Called after signature expiry |
 | `InvalidExpiries` | Expiry timestamps are improperly ordered |
-| `FeeBpsOverFlow` | maxFeeBps exceeds maximum value |
+| `FeeBpsOverflow` | maxFeeBps exceeds maximum value |
 | `InvalidFeeBpsRange` | minFeeBps exceeds maxFeeBps |
 | `FeeBpsOutOfRange` | Fee outside min/max range |
 | `ZeroFeeReceiver` | Fee recipient is zero address with non-zero fee |


### PR DESCRIPTION
Found a few doc issues in the operations docs and README.

README.md said payerss instead of payers.

Capture.md and Charge.md linked to Fees.md as if it were in the same folder, but it lives in docs/. Fixed the relative path to ../Fees.md so the links resolve.

Authorize.md and Charge.md listed the error as FeeBpsOverFlow but the actual error in AuthCaptureEscrow.sol is FeeBpsOverflow. Fixed the casing.
