### PR TITLE
ci: pin Foundry to v1.3.6 for reproducible formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
         with:
-          version: nightly
+          version: "v1.3.6"
 
       - name: Show Forge version
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Formatting
+
+CI enforces `forge fmt` with a pinned Foundry version (**v1.3.6**) so formatting is
+reproducible regardless of your local Foundry. Before committing:
+
+```sh
+make fmt         # format using the pinned version
+make fmt-check   # verify (identical to the CI check)
+```
+
+`make fmt` installs Foundry v1.3.6 side-by-side on first run — it does not have to be
+your default. The initial install switches your active Foundry to v1.3.6; run
+`foundryup -u stable` to switch back.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Foundry version CI uses for `forge fmt`. Pinned so formatting output is
+# reproducible regardless of your default Foundry install.
+FMT_VER := 1.3.6
+FORGE_FMT := $(HOME)/.foundry/versions/v$(FMT_VER)/forge
+
+.PHONY: fmt fmt-check
+
+## Format all Solidity with the pinned Foundry version (installed side-by-side on first run).
+fmt:
+	@[ -x "$(FORGE_FMT)" ] || foundryup -i $(FMT_VER) >/dev/null
+	@"$(FORGE_FMT)" fmt
+
+## Verify formatting - identical to the CI check.
+fmt-check:
+	@[ -x "$(FORGE_FMT)" ] || foundryup -i $(FMT_VER) >/dev/null
+	@"$(FORGE_FMT)" fmt --check


### PR DESCRIPTION
## What
Pin CI's Foundry to `v1.3.6` (was floating `nightly`) and add `make fmt` / `make fmt-check` helpers.

## Why
`forge fmt` output changes between Foundry versions, and CI used `version: nightly` — a moving target. Contributors on differing local Foundry versions produce formatting churn that pollutes diffs (e.g. unrelated call-wrapping changes) even when CI happens to pass. Pinning makes `forge fmt --check` deterministic.

`v1.3.6` is the newest release under which `main` is already clean, so this PR reformats nothing and CI stays green on its own. (The formatter's call-wrapping behavior changed in v1.4.0.)

## Changes
- `.github/workflows/test.yml`: `version: nightly` → `version: "v1.3.6"`
- `Makefile`: `make fmt` / `make fmt-check` run the pinned version (installed side-by-side; your default Foundry is untouched)
- `CONTRIBUTING.md`: formatting note

## Follow-up
Feature branches should rebase on this and run `make fmt` so their diffs show only the real changes.
